### PR TITLE
Chatting Without A Knowledge Base Works Again

### DIFF
--- a/app/controls/illiana/chat.py
+++ b/app/controls/illiana/chat.py
@@ -65,7 +65,7 @@ class ChatMessage(ft.Column):
 class ChatView(ft.Container):
     def __init__(self, chat_config: ChatConfig, page: ft.Page) -> None:
         super().__init__(**styles.ChatWindowStyle().to_dict())
-        self.chat = ft.ListView(expand=True, height=200, spacing=10)
+        self.chat = ft.ListView(expand=True, height=200, spacing=15)
         self.content = self.chat
         self.chat_config = chat_config
         self.page = page
@@ -147,12 +147,13 @@ class MessageHandler:
         )
         response, refreshed_vectorstore = ai.chat_with_llm(
             user_input=user_input,
-            document_data=self.chat_view.chat_config.knowledge_base_helper.document_data[
-                knowledge_base_name
-            ],
+            document_data=self.chat_view.chat_config.knowledge_base_helper.document_data.get(  # noqa
+                knowledge_base_name, {}
+            ),
             model=self.chat_view.chat_config.llm_dropdown.dropdown.value,
             context_window=self.chat_view.chat_config.llm_context_window.value,
             knowledge_base_name=knowledge_base_name,
+            use_knowledge_base=self.chat_view.chat_config.use_knowledge_base_checkbox.value,  # noqa
         )
 
         # Remove progress ring

--- a/app/controls/illiana/chat_config.py
+++ b/app/controls/illiana/chat_config.py
@@ -101,6 +101,11 @@ class ChatConfig(ft.UserControl):
             file_picker_control=self.file_picker_control,
             delete_file_handler=self.delete_file,
         )
+        self.use_knowledge_base_checkbox = ft.Checkbox(
+            check_color="#FFFFFF",
+            fill_color=styles.ColorPalette.ACCENT,
+            value=True,
+        )
 
     def on_llm_selection_change(self, event: ft.ControlEvent):
         selected_llm = event.control.value
@@ -123,7 +128,7 @@ class ChatConfig(ft.UserControl):
         llm_names = list(settings.LLMS.keys())
         return DropdownControl(
             options=llm_names,
-            label="LLM Selection",
+            label="LLM",
             width=260,
             on_change=lambda event: self.on_llm_selection_change(event),
             default_value="gpt-3.5-turbo-1106",
@@ -345,6 +350,16 @@ class ChatConfig(ft.UserControl):
                             ),
                         ],
                         alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                    ),
+                    ft.Row(
+                        controls=[
+                            self.use_knowledge_base_checkbox,
+                            ft.Text(
+                                "Use Knowledge Base",
+                                **styles.SecondaryTextStyle().to_dict(),
+                            ),
+                        ],
+                        alignment=ft.MainAxisAlignment.START,
                     ),
                     self.loading_indicator,
                     ft.Divider(),

--- a/app/core/ai.py
+++ b/app/core/ai.py
@@ -45,6 +45,7 @@ def chat_with_llm(
     model: str = "gpt-3.5-turbo-1106",
     temperature: float = 0.0,
     document_data: dict[str, bytes] = {},
+    use_knowledge_base: bool = False,
 ) -> Tuple[dict, bool]:
     logger.debug(
         "llm.chat",
@@ -53,6 +54,7 @@ def chat_with_llm(
         temperature=temperature,
         context_window=context_window,
         files=document_data.keys(),
+        use_knowledge_base=use_knowledge_base,
     )
 
     llm = ChatOpenAI(
@@ -81,7 +83,7 @@ def chat_with_llm(
     prompt = conversation_prompts[knowledge_base_name]
 
     refreshed_vectorstore: bool = False
-    if knowledge_base_name and document_data:
+    if use_knowledge_base and knowledge_base_name and document_data:
         chunked_documents: list[Document] = []
         # Check for the existence of the vectorstore
         if not vectorstore_exists(knowledge_base_name):

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
         },
     }
 
+    VECTORSTORE_MAX_DOCUMENTS: int = 10
     VECTORSTORE_ROOT_DIR: str = "data/vectorstore"
     VECTORSTORE_KNOWLEDGE_BASE_DIR: str = f"{VECTORSTORE_ROOT_DIR}/knowledge_base"
     VECTORSTORE_CHROMADB_DIR: str = f"{VECTORSTORE_ROOT_DIR}/chromadb"

--- a/app/core/vectorstore.py
+++ b/app/core/vectorstore.py
@@ -149,7 +149,7 @@ def get_vectorstore_retriever(
     documents: list[Document],
     embeddings: Embeddings,
     knowledge_base_name: str,
-    max_documents: int = 10,
+    max_documents: int = settings.VECTORSTORE_MAX_DOCUMENTS,
     persist_directory_root: str = settings.VECTORSTORE_CHROMADB_DIR,
 ) -> VectorStoreRetriever:
     """

--- a/data/knowledge_base/knowledge_base.json
+++ b/data/knowledge_base/knowledge_base.json
@@ -1,1 +1,170 @@
-{}
+{
+    "podcasts": {
+        "Podcasts Ingestion Playbook - iHR Engineering - Confluence.html": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/podcasts/Podcasts Ingestion Playbook - iHR Engineering - Confluence.html",
+            "Size": 1227147,
+            "Loaded": true
+        }
+    },
+    "Flet": {
+        "flet completo.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Flet/flet completo.docx",
+            "Size": 268413,
+            "Loaded": true
+        }
+    },
+    "Rose Of Eternity": {
+        "Rose Of Eternity - Random Notes.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/Rose Of Eternity - Random Notes.docx",
+            "Size": 12098,
+            "Loaded": true
+        },
+        "ROE Bible.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/ROE Bible.docx",
+            "Size": 30770,
+            "Loaded": true
+        },
+        "Cast.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/Cast.docx",
+            "Size": 15616,
+            "Loaded": true
+        },
+        "Rose of Eternity - Ability Ideas.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/Rose of Eternity - Ability Ideas.docx",
+            "Size": 7708,
+            "Loaded": true
+        },
+        "Legacy.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/Legacy.docx",
+            "Size": 7795,
+            "Loaded": true
+        },
+        "Random.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/Random.docx",
+            "Size": 7770,
+            "Loaded": true
+        },
+        "History.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/History.docx",
+            "Size": 8033,
+            "Loaded": true
+        },
+        "Challseus_ Escape.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/Challseus_ Escape.docx",
+            "Size": 7560,
+            "Loaded": true
+        },
+        "Rose of Eternity - Quotes.docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Rose Of Eternity/Rose of Eternity - Quotes.docx",
+            "Size": 6430,
+            "Loaded": true
+        }
+    },
+    "Daily Journal": {
+        "december_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/december_2006.htm",
+            "Size": 109381,
+            "Loaded": true
+        },
+        "november_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/november_2006.htm",
+            "Size": 116316,
+            "Loaded": true
+        },
+        "october_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/october_2006.htm",
+            "Size": 227107,
+            "Loaded": true
+        },
+        "june_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/june_2006.htm",
+            "Size": 104808,
+            "Loaded": true
+        },
+        "may_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/may_2006.htm",
+            "Size": 131672,
+            "Loaded": true
+        },
+        "april_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/april_2006.htm",
+            "Size": 119170,
+            "Loaded": true
+        },
+        "march_2006.html": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/march_2006.html",
+            "Size": 137849,
+            "Loaded": true
+        },
+        "february_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/february_2006.htm",
+            "Size": 106720,
+            "Loaded": true
+        },
+        "january_2006.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/january_2006.htm",
+            "Size": 130443,
+            "Loaded": true
+        },
+        "december_2005.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/december_2005.htm",
+            "Size": 157664,
+            "Loaded": true
+        },
+        "november_2005.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/november_2005.htm",
+            "Size": 122433,
+            "Loaded": true
+        },
+        "october_2005.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/october_2005.htm",
+            "Size": 109916,
+            "Loaded": true
+        },
+        "september_2005.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/september_2005.htm",
+            "Size": 116298,
+            "Loaded": true
+        },
+        "august_2005.htm": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Daily Journal/august_2005.htm",
+            "Size": 63331,
+            "Loaded": true
+        }
+    },
+    "Resume": {
+        "Backend Engineer Resume (1).docx": {
+            "Type": "Document",
+            "Filepath": "data/vectorstore/knowledge_base/Resume/Backend Engineer Resume (1).docx",
+            "Size": 9923,
+            "Loaded": true
+        }
+    },
+    "Upwork": {},
+    "Test": {}
+}


### PR DESCRIPTION
- now properly handling empty `document_data`
- if "Use Knowledge Base" checkbox is not checked, LLM reverts back to normal Q&A without using documents for context
- minor fixes
<img width="1792" alt="Screen Shot 2023-12-26 at 8 40 45 PM" src="https://github.com/lbedner/ee-toolset/assets/3474138/e7cd63c2-5df4-450d-8f1e-70316722cc98">
